### PR TITLE
Adding recursion of nested structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ td-agent-gem install fluent-plugin-dedot_filter
 
 * `de_dot` (default: true)
 * `de_dot_separator` (default: '_')
+* `de_dot_nested` (default: false)
 
 `de_dot_separator` cannot be or contain '.'.
+`de_dot_nested` will cause the plugin to recurse through nested structures (hashes and arrays), and remove dots in those key-names too.
 
 ## License
 

--- a/lib/fluent/plugin/filter_dedot/version.rb
+++ b/lib/fluent/plugin/filter_dedot/version.rb
@@ -1,7 +1,7 @@
 module Fluent
   module Plugin
     module DedotFilter
-      VERSION = "0.1.0"
+      VERSION = "0.2.0"
     end
   end
 end


### PR DESCRIPTION
This change allows the de_dot filter to remove dots from the key-names of nested object structures (hashes and arrays).
