### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-dedot_filter.gemspec
+++ b/fluent-plugin-dedot_filter.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "fluentd", ">= 0"
+  spec.add_runtime_dependency "fluentd", [">= 0.14.0", "< 2"]
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/fluent/plugin/filter_dedot.rb
+++ b/lib/fluent/plugin/filter_dedot.rb
@@ -1,5 +1,7 @@
-module Fluent
-  class DedotFilter < Fluent::Filter
+require 'fluent/plugin/filter'
+
+module Fluent::Plugin
+  class DedotFilter < Filter
 
     Fluent::Plugin.register_filter('dedot', self)
 

--- a/lib/fluent/plugin/filter_dedot/version.rb
+++ b/lib/fluent/plugin/filter_dedot/version.rb
@@ -1,6 +1,8 @@
+require 'fluent/plugin/filter'
+
 module Fluent
   module Plugin
-    module DedotFilter
+    class DedotFilter < Filter
       VERSION = "0.2.0"
     end
   end

--- a/spec/filter_dedot_spec.rb
+++ b/spec/filter_dedot_spec.rb
@@ -3,18 +3,18 @@
 require 'helper'
 
 class TestDedotFilter
-  RSpec.describe Fluent::DedotFilter do
+  RSpec.describe Fluent::Plugin::DedotFilter do
 
     CONFIG = %[]
 
-    def create_driver(conf=CONFIG, tag='test')
-      Fluent::Test::FilterTestDriver.new(Fluent::DedotFilter, tag)
+    def create_driver(conf=CONFIG)
+      Fluent::Test::Driver::Filter.new(Fluent::Plugin::DedotFilter)
     end
 
     def create_filter
-      Fluent::DedotFilter.new
+      Fluent::Plugin::DedotFilter.new
     end
-    
+
     before :all do
       Fluent::Test.setup
     end
@@ -133,7 +133,7 @@ class TestDedotFilter
       end
 
     end
-    
+
   end
 
 end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -25,4 +25,5 @@ unless ENV.has_key?('VERBOSE')
 end
 
 require 'fluent/test'
+require 'fluent/test/driver/filter'
 require 'fluent/plugin/filter_dedot'


### PR DESCRIPTION
I've tried to migrate to use v0.14 Filter Plugin API.
This PR contains major update change and also includes in breaking changes.
If above questions/problems are acceptable or reasonable for you, could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks.